### PR TITLE
add --clock-only feature

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -67,7 +67,11 @@ static inline void start_bank_2() {
 gamepad_t read_buttons() {
     gamepad_t gamepad = 0;
     gamepad = stock_read_buttons();
-    if((gamepad & GAMEPAD_LEFT) && (gamepad & GAMEPAD_A) && (gamepad & GAMEPAD_GAME)){
+#if CLOCK_ONLY
+    if(gamepad & GAMEPAD_GAME){
+#else
+    if((gamepad & GAMEPAD_LEFT) && (gamepad & GAMEPAD_GAME)){
+#endif
         start_bank_2();
     }
     return gamepad;

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ C_DEFS =  \
 -DUSE_HAL_DRIVER \
 -DSTM32H7B0xx \
 
+ifneq (,$(findstring --clock-only, $(PATCH_PARAMS)))
+	C_DEFS += -DCLOCK_ONLY
+endif
 
 # AS includes
 AS_INCLUDES = 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ functionality to the stock Game and Watch firmware. This is the only custom firm
 
 # Features
 * Works correctly with [retro-go](https://github.com/kbeckmann/game-and-watch-retro-go) in internal flash bank 2.
-* Press button combination (`LEFT` + `A` + `GAME`) to launch retro-go from internal flash bank 2.
+* Press button combination (`LEFT` + `GAME`) to launch retro-go from internal flash bank 2.
 * Configurable sleep timeout.
 * Configurable hard-reset timeout.
 * Reduced external flash firmware size `--slim`; reduced from 1,048,576 bytes to just **180,224** bytes
@@ -19,7 +19,9 @@ functionality to the stock Game and Watch firmware. This is the only custom firm
     * Removed the 5 sleeping illustrations.
     * LZMA compressed SMB2 ROM and Clock graphic tiles.
     * Move Clock graphic tiles to internal flash. 
-
+* An even further stripped version `--clock-only` that further reduces extflash size to just **139,264** bytes. Uses all the techniques described in `slim` plus:
+    * Removed SMB2 ROM.
+    * Set retro-go macro to just `GAME`.
 
 # Usage
 Place your `internal_flash_backup.bin` and `flash_backup.bin` in the root of this
@@ -88,10 +90,8 @@ make flash_patch_ext
 * Figure out safe place in RAM to store global/static variables. The current
   configuration described in the linker file is unsafe, but currently we have
   no global/static variables.
-  * Currently we cannot use zlib/zopfli compression for assets because it
-    requires some globals in RAM. So in order to do that, we need to find
-    some unused ram first. This could improve compression a bit.
 * Custom sprites for clock.
+* Add option to move external flash assets to the extended region of bank 1.
 
 # Development
 Main stages to developing a feature:


### PR DESCRIPTION
removes SMB2 and updates the retro-go macro to just `GAME`. More space savings to come in the future.