### PR TITLE
Build and flash using Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,32 @@ make clean
 # In this example, I'm assuming you have a 64MB flash chip (60 = 64 - 4)
 make -j8 EXTFLASH_SIZE_MB=60 EXTFLASH_OFFSET=4194304 INTFLASH_BANK=2 flash
 ```
+## Build and flash using Docker
 
+<details>
+  <summary>
+    If you are familiar with Docker and prefer a solution where you don't have to manually install toolchains and so on, expand this section and read on.    
+  </summary>  
+  To reduce the number of potential pitfalls in installation of various software, a Dockerfile is provided containing everything needed to compile and flash Custom Firmware (CFW) to your Nintendo® Game & Watch™ system. This Dockerfile is written tageting an x86-64 machine running Linux.
+
+  Steps to build and flash from a docker container (running on Linux, e.g. Archlinux or Ubuntu):
+
+  ```bash
+  # Copy the content of a docker directory from this repo. To create the image, cd to the folder where you put the files and type:
+  sudo docker build -t game-and-watch-patch:latest .
+
+  # When done, use the image to create a container with the attached docker-compose.yaml file.
+  # You have to edit the compose file and set the path to the directory with your firmware backup (volumes section of the file).
+  sudo docker compose up -d
+
+  # This will create and run a container game-and-watch-patch.
+  # The firmware backup files will be mounted into /tmp/firmware of the container.
+  # Now, go inside the container copy the backup files and proceed as described above in the Usage section.
+  sudo docker exec -it game-and-watch-patch /bin/bash
+  
+  ```
+
+</details>
 
 
 # Troubleshooting/FAQ:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -yqq \
+    make \
+    python3 \
+    python3-pip \
+    wget \
+    unzip \
+    libftdi1 libftdi1-2 libhidapi-hidraw0 libusb-0.1-4 libusb-1.0-0 \
+    git && \
+    wget https://nightly.link/kbeckmann/ubuntu-openocd-git-builder/workflows/docker/master/openocd-git.deb.zip && \
+    unzip openocd-git.deb.zip && \
+    dpkg -i openocd-git_*_amd64.deb && \
+    rm openocd-git.deb.zip && \
+    rm openocd-git_*_amd64.deb && \
+    cd /root && \
+    git clone https://github.com/BrianPugh/game-and-watch-patch.git && \
+    cd /opt && \
+    wget "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2" && \
+    tar -jxf gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 && \
+    rm gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+WORKDIR /root/game-and-watch-patch

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  game-and-watch-patch:
+    container_name: game-and-watch-patch
+    image: game-and-watch-patch:latest
+    network_mode: host
+    restart: "no"
+    privileged: true
+    environment:
+      - PATH=/opt/openocd-git/bin:/opt/gcc-arm-none-eabi-10.3-2021.10/bin:$PATH
+    volumes:
+      - /dev/bus/usb:/dev/bus/usb
+      - </path/to/your/flash/backup>:/tmp/firmware
+    command:
+      - /bin/bash
+      - -c
+      - |
+        while true; do sleep 10; done;
+


### PR DESCRIPTION

Use of pip is deprecated in new releases of Ubuntu, Fedora, Debian and Arch, as described here [https://itsfoss.com/externally-managed-environment/](https://itsfoss.com/externally-managed-environment/). To make the game-and-watch-patch work with the newest system, I have created a simple Dockerfile and compose file with a short description how to use it. I believe it could be helpful for a lot of people with newer OS. Thank you for your great work!

