### PR TITLE
Added an option to remove the annoying second beep in TIME/CLOCK on Zelda devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repo contains custom code as well as a patching utility to add additional f
 * See [the mario document for more information](docs/mario.md).
 
 ### Zelda (`PATCH_PARAMS="--device=zelda"`)
-* No extra features currently implemented, just compatible with retro-go
+* Ability to remove the second beep in TIME/CLOCK via `--no-beep`
 * External flash savings to come in the future.
 * See [the zelda document for more information](docs/zelda.md).
 

--- a/patches/zelda.py
+++ b/patches/zelda.py
@@ -363,7 +363,7 @@ class ZeldaGnW(Device, name="zelda"):
 
         if self.args.no_beep:
             # Disable TIME/CLOCK second beep
-            self.external.nop(0x0032002c, 4)
+            self.external.nop(0x0032002C, 4)
 
         if False:
             # This doesn't quite work yet

--- a/patches/zelda.py
+++ b/patches/zelda.py
@@ -116,6 +116,11 @@ class ZeldaGnW(Device, name="zelda"):
             help="Override LoZ2 ROM with your own file.",
         )
 
+        group.add_argument(
+            "--no-beep",
+            action="store_true",
+            help="Remove the second beep in TIME/CLOCK.",
+        )
         self.args = parser.parse_args()
         return self.args
 
@@ -355,6 +360,10 @@ class ZeldaGnW(Device, name="zelda"):
             self.internal.nop(0x16536, 2)
             self.internal.nop(0x1653A, 1)
             self.internal.nop(0x1653C, 1)
+
+        if self.args.no_beep:
+            # Disable TIME/CLOCK second beep
+            self.external.nop(0x0032002c, 4)
 
         if False:
             # This doesn't quite work yet


### PR DESCRIPTION
This PR will add an option to enable users to remove the very annoying beep that occurs each second while in TIME/CLOCK.