### PR TITLE
store firmware metadata in vector table

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,10 @@ At this location we store the following data:
 ```C
 struct {
   external_flash_size: 24; // This value * 4096 is the amount of external flash used by this firmware.
+  must_be_4: 4; // "magic" value that would never be valid in any real hdmi-cec firmware. 0x4 is in the hardware perhipheral space.
   is_mario: 1;  // This is the mario firmware.
   is_zelda: 1;  // This is the zelda firmware.
-  _unused: 6;   // Reserved for future use. All 0 for now.
+  _unused: 2;   // Reserved for future use. All 0 for now.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ Main stages to developing a feature:
 3. Implement your own function, possibly in `Core/Src/main.c`. There's a good chance your custom function will call the function in (2). You will also probably have to add `-Wl,--undefined=my_custom_function` to `LDFLAGS` in the Makefile so that it doesn't get optimized out as unreachable code.
 4. Add a patch definition to `patches/patches.py`.
 
+### Protocols
+We store information about how much external flash this firmware uses at internal-flash offset `0x01B8`.
+This location is in the HDMI-CEC handler in the vector-table; this is unused for all game-and-watch purposes, so serves as a safe, standardized spot to put a bit of data.
+At this location we store the following data:
+
+```C
+struct {
+  external_flash_size: 24; // This value * 4096 is the amount of external flash used by this firmware.
+  is_mario: 1;  // This is the mario firmware.
+  is_zelda: 1;  // This is the zelda firmware.
+  _unused: 6;   // Reserved for future use. All 0 for now.
+}
+```
+
+
 # Journal
 This is my first time ever developing patches for a closed source binary. [I documented my journey in hopes that it helps other people](docs/journal.md). If you have any recommendations, tips, tricks, or anything like that, please leave a github issue and I'll update the documentation!
 

--- a/patches/firmware.py
+++ b/patches/firmware.py
@@ -42,13 +42,19 @@ class Lookup(dict):
         return "\n".join(substrs)
 
 
+METADATA_MAGIC = 0x4  # chosen because no real executable code starts with address 0x4
+
+
 @dataclass
 class HeaderMetaData:
     """4 bytes of data that can be stored at the hdmi-cec handler in the vector-table (0x01B8)"""
 
     external_flash_size: int  # Actual size in bytes (will be divided by 4096 for storage)
+
+    # 4 LSb are used for MAGIC
     is_mario: bool  # 1 bit
     is_zelda: bool  # 1 bit
+    # 2 MSb are free
 
     def pack(self) -> bytes:
         # Convert size to 4K blocks (right shift by 12)
@@ -61,7 +67,7 @@ class HeaderMetaData:
             )
 
         # Pack the flags into a single byte
-        flags = (int(self.is_mario) << 0) | (int(self.is_zelda) << 1)
+        flags = METADATA_MAGIC | (int(self.is_mario) << 4) | (int(self.is_zelda) << 5)
 
         # Pack as little-endian:
         # - First 3 bytes: external_flash_size
@@ -77,8 +83,10 @@ class HeaderMetaData:
         # Convert from 4K blocks back to bytes (left shift by 12)
         external_flash_size = (value & 0xFFFFFF) << 12
         flags = (value >> 24) & 0xFF
-        is_mario = bool(flags & (1 << 0))
-        is_zelda = bool(flags & (1 << 1))
+        if (flags & 0x0F) != METADATA_MAGIC:
+            raise ValueError("Invalid Magic.")
+        is_mario = bool(flags & (1 << 4))
+        is_zelda = bool(flags & (1 << 5))
 
         return cls(external_flash_size, is_mario, is_zelda)
 


### PR DESCRIPTION
Stores 4-bytes of data at the fixed, static offset `0x01b8` so that downstream firmwares can parse this data.