### PR TITLE
Fix int/pointer conversion errors that break GCC 14+ builds

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -168,15 +168,15 @@ gamepad_t read_buttons() {
 #endif
         uint32_t *target_address;
 #if SD_BOOTLOADER
-        target_address = SD_BOOTLOADER_ADDRESS;
+        target_address = (uint32_t *)SD_BOOTLOADER_ADDRESS;
 #else
-        target_address = BANK_2_ADDRESS;
+        target_address = (uint32_t *)BANK_2_ADDRESS;
 #endif
         uint32_t sp = *target_address;
         uint32_t pc = *(target_address + 1);
 
         if(is_valid(pc, sp)){
-            set_bootloader(target_address);
+            set_bootloader((uint32_t)target_address);
             NVIC_SystemReset();
         }
     }


### PR DESCRIPTION
`BANK_2_ADDRESS` / `SD_BOOTLOADER_ADDRESS` are plain int literals; 974c49b assigned them to a `uint32_t *` and passed that pointer back into `set_bootloader(uint32_t)`. GCC <=13 warned, GCC 14+ errors (`-Wint-conversion` is an error by default). Added the casts — no behavior change.

Verified with Arm GNU Toolchain 15.2.Rel1: full mario and zelda builds pass, and `main.c` compiles clean under `SD_BOOTLOADER` / `TRIPLE_BOOT` / `CLOCK_ONLY` / `ENABLE_SMB1_GRAPHIC_MODS`.

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)